### PR TITLE
One line comments inside method body

### DIFF
--- a/src/main/scala/org/arnoldc/ArnoldParser.scala
+++ b/src/main/scala/org/arnoldc/ArnoldParser.scala
@@ -65,7 +65,7 @@ class ArnoldParser extends Parser {
   def Statement: Rule1[StatementNode] = rule {
     DeclareIntStatement | PrintStatement |
       AssignVariableStatement | ConditionStatement |
-      WhileStatement | CallMethodStatement | ReturnStatement
+      WhileStatement | CallMethodStatement | ReturnStatement | Comment
   }
 
   def CallMethodStatement: Rule1[StatementNode] = rule {
@@ -182,6 +182,10 @@ class ArnoldParser extends Parser {
     zeroOrMore(rule {
       !anyOf("\"\\") ~ ANY
     }) ~> StringNode
+  }
+
+  def Comment: Rule1[CommentNode] = rule {
+    "#" ~ rule {zeroOrMore(noneOf("\n\r"))} ~ EOL ~> CommentNode
   }
 
   def parse(expression: String): RootNode = {

--- a/src/main/scala/org/arnoldc/ast/CommentNode.scala
+++ b/src/main/scala/org/arnoldc/ast/CommentNode.scala
@@ -1,0 +1,8 @@
+package org.arnoldc.ast
+
+import org.objectweb.asm.MethodVisitor
+import org.arnoldc.SymbolTable
+
+case class CommentNode(text: String) extends StatementNode{
+  override def generate(mv: MethodVisitor, symbolTable: SymbolTable){}
+}

--- a/src/test/scala/org/arnoldc/CommentsTest.scala
+++ b/src/test/scala/org/arnoldc/CommentsTest.scala
@@ -1,0 +1,13 @@
+package org.arnoldc
+
+
+class CommentsTest extends ArnoldGeneratorTest{
+  it should "comment line inside method body" in {
+    val code =
+      "IT'S SHOWTIME\n" +
+      "#Comment\n" +
+      "TALK TO THE HAND \"Hello\"\n" +
+      "YOU HAVE BEEN TERMINATED\n"
+    getOutput(code) should equal("Hello\n")
+  }
+}


### PR DESCRIPTION
I added the possibility to comment code but only inside method body. Probably this implementation is not so pure.
