### PR TITLE
Fix error parsing expression, adding a blank line to separate commands.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,4 +27,5 @@ libraryDependencies ++= Seq(
 )
 
 resolvers += "Speech" at "http://maven.it.su.se/it.su.se/maven2"
+
 parallelExecution in Test := false


### PR DESCRIPTION
Trying to compile the project I got the following error:

`build.sbt:30: error: eof expected but ';' found.`
`parallelExecution in Test := false`
`^`
`[error] Error parsing expression.  Ensure that settings are separated by blank lines.`
`Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? r`

Then I check the **build.sbt** and saw the last commit adding **parallelExecution** setup.
I added the blank line separating the commands to can start to contribute with ArnoldC :)


